### PR TITLE
Use fetch content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ add_compile_options(-Wall -Werror -Wunused -Wunused-parameter -pedantic)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "Use external fmt library")
 
 include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,33 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 
-find_package(fmt REQUIRED)
-find_package(spdlog REQUIRED)
+include(FetchContent)
+
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG        10.2.1
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(fmt)
+
+FetchContent_Declare(
+  spdlog
+  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+  GIT_TAG        v1.13.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(spdlog)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.5.2
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(Catch2)
+
 find_package(TBB REQUIRED)
-find_package(Catch2 REQUIRED)
 
 add_subdirectory(serial)
 

--- a/test/serializer-scary.cpp
+++ b/test/serializer-scary.cpp
@@ -7,7 +7,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <format>
 #include <iostream>
 #include <string>
 

--- a/test/serializer-scary.cpp
+++ b/test/serializer-scary.cpp
@@ -3,6 +3,7 @@
 
 #include "oneapi/tbb/flow_graph.h"
 #include "spdlog/spdlog.h"
+#include "fmt/chrono.h"
 
 #include <atomic>
 #include <chrono>

--- a/test/serializer.cpp
+++ b/test/serializer.cpp
@@ -5,7 +5,6 @@
 #include "spdlog/spdlog.h"
 
 #include <atomic>
-#include <format>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
These commits switch the build to getting fmt, spdlog and catch2 with FetchContent.

It is still expected that TBB is available from "the environment", with no specification of how that environment was established. I have tested it on macOS with TBB from Homebrew and also with TBB from spack, and on Linux with TBB from mamba.

In order to get spdlog to build with the same fmt used elsewhere in the code, the cmake command line needs to include `-DSPDLOG_FMT_EXTERNAL=On`.